### PR TITLE
fix for two argument call from javascript

### DIFF
--- a/src/android/CDVInstagramPlugin.java
+++ b/src/android/CDVInstagramPlugin.java
@@ -63,7 +63,7 @@ public class CDVInstagramPlugin extends CordovaPlugin {
 		
         if (action.equals("share")) {
             String imageString = args.getString(0);
-            String captionString = args.getString(1);
+            String captionString = (args.getString(1) == "null") ? "" : args.getString(1);
             this.share(imageString, captionString);
             return true;
         } else if (action.equals("isInstalled")) {


### PR DESCRIPTION
https://github.com/vstirbu/InstagramPlugin/pull/30 was putting the text 'null' as a caption with a two argument call to Instagram.share() from javascript.  Feel free to implement this fix differently if you prefer.
