### PR TITLE
added logging of missing image magic.

### DIFF
--- a/www/CDVInstagramPlugin.js
+++ b/www/CDVInstagramPlugin.js
@@ -92,6 +92,10 @@ var Plugin = {
     else if (data.slice(0, magic.length) == magic) {
       shareDataUrl(data, caption, callback);
     }
+    else
+    {
+      console.log('oops, Instagram image data lacks magic.')
+    }
   }
 };
 

--- a/www/CDVInstagramPlugin.js
+++ b/www/CDVInstagramPlugin.js
@@ -94,7 +94,7 @@ var Plugin = {
     }
     else
     {
-      console.log('oops, Instagram image data lacks magic.')
+      console.log("oops, Instagram image data string has to start with 'data:image'.")
     }
   }
 };


### PR DESCRIPTION
For easier debugging, provide log ouput when supplied image data lacks the "magic" part. Without this, sharing fails silently when the magic is missing.