### PR TITLE
White list custom URL on iOS

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -44,6 +44,13 @@
       </feature>
     </config-file>
 
+    <!-- custom URLs need to be white listed on iOS 9 -->
+    <config-file target="*-Info.plist" parent="LSApplicationQueriesSchemes">
+      <array>
+        <string>instagram</string>
+      </array>
+    </config-file>
+
     <header-file src="src/ios/CDVInstagramPlugin.h" target-dir="CDVInstagramPlugin" />
     <source-file src="src/ios/CDVInstagramPlugin.m" target-dir="CDVInstagramPlugin" />
   </platform>


### PR DESCRIPTION
Fixes #47 

Tested to work on iPhone 6 / iOS 9.0.1

Didn't test whether *.plist values from other plugins get overwritten or not