### PR TITLE
dataFromBase64String fix for cordova-ios 4.x.x

### DIFF
--- a/src/ios/CDVInstagramPlugin.m
+++ b/src/ios/CDVInstagramPlugin.m
@@ -60,7 +60,7 @@ static NSString *InstagramId = @"com.burbn.instagram";
     if ([[UIApplication sharedApplication] canOpenURL:instagramURL]) {
         NSLog(@"open in instagram");
         
-        NSData *imageObj = [NSData dataFromBase64String:objectAtIndex0];
+        NSData *imageObj = [[NSData alloc] initWithBase64EncodedString:objectAtIndex0 options:0];
         NSString *tmpDir = NSTemporaryDirectory();
         NSString *path = [tmpDir stringByAppendingPathComponent:@"instagram.igo"];
         


### PR DESCRIPTION
It looks as though `dataFromBase64String` was deprecated in `3.8.0` and removed in `4.x.x`. The following commit fixes it for `cordova-ios 4.x.x`.

Additional information see issue #56.