### PR TITLE
Fix copying caption to clipboard functionality

### DIFF
--- a/www/CDVInstagramPlugin.js
+++ b/www/CDVInstagramPlugin.js
@@ -30,17 +30,19 @@ var hasCheckedInstall,
 function shareDataUrl(dataUrl, caption, callback) {
   var imageData = dataUrl.replace(/data:image\/(png|jpeg);base64,/, "");
 
-  exec(function () {
     if (cordova && cordova.plugins && cordova.plugins.clipboard && caption !== '') {
+      console.log("copying caption: ", caption);
       cordova.plugins.clipboard.copy(caption);
     }
 
-    callback && callback(null, true);
-  },
-
-  function (err) {
-    callback && callback(err);
-  }, "Instagram", "share", [imageData, caption]);
+    exec(
+        function () {
+            callback && callback(null, true);
+        },
+        function (err) {
+            callback && callback(err);
+        }, "Instagram", "share", [imageData, caption]
+    );
 }
 
 var Plugin = {


### PR DESCRIPTION
The existing code does not copy the caption to the clipboard until after sharing because it's being executed in the callback from the plugin native code.