### PR TITLE
Fix Instagram iOS doc url

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ $cordovaFileTransfer.download(url, targetPath, {}, true).then(function(result) {
 
 #### iOS
 
-* Although the plugin follows the [instructions](http://instagram.com/developer/iphone-hooks/) to show only Instagram in the document interaction controller, there are [reports](https://github.com/vstirbu/InstagramPlugin/issues/23) that other apps appear in the list.
+* Although the plugin follows the [instructions](https://www.instagram.com/developer/mobile-sharing/iphone-hooks/) to show only Instagram in the document interaction controller, there are [reports](https://github.com/vstirbu/InstagramPlugin/issues/23) that other apps appear in the list.
 
 ### Recipes
 


### PR DESCRIPTION
Look like Instagram moved the "Mobile Sharing>iOS" documentation page. This PR just reflect the new url in the README.md