### PR TITLE
Fix broken FileProvider paths.

### DIFF
--- a/src/android/CDVInstagramPlugin.java
+++ b/src/android/CDVInstagramPlugin.java
@@ -45,7 +45,7 @@ import android.net.Uri;
 import android.os.Build;
 import android.util.Base64;
 import android.util.Log;
-import android.support.v4.content.FileProvider;
+import androidx.core.content.FileProvider;
 
 @TargetApi(Build.VERSION_CODES.FROYO)
 public class CDVInstagramPlugin extends CordovaPlugin {

--- a/src/android/utils/AssetProvider.java
+++ b/src/android/utils/AssetProvider.java
@@ -19,7 +19,7 @@
 
 package com.vladstirbu.cordova.plugin.utils;
 
-import android.support.v4.content.FileProvider;
+import androidx.core.content.FileProvider;
 
 public class AssetProvider extends FileProvider {
     // Nothing to do here


### PR DESCRIPTION
Per this Stack Overflow post [here](https://stackoverflow.com/a/54297708):

```
As of AndroidX (the repackaged Android Support Library), the path is androidx.core.content.FileProvider.
Android Support Libraries are now in the androidx.* package hierarchy. 
android.* is now reserved to the built-in Android System Libraries.
```

For proof of this in the Android documentation, please see this link [here](https://developer.android.com/jetpack/androidx/migrate/class-mappings).

If these paths aren't fixed, I get these errors about incorrect import paths in `AssetProvider.java` and `CDVInstagramPlugin.java`:

<img width="1440" alt="Screen Shot 2021-02-12 at 3 36 50 PM" src="https://user-images.githubusercontent.com/16109633/107820072-33db1200-6d48-11eb-9f8a-fe0d9a37b837.png">


