### PR TITLE
Added support for converting base64/canvas into Library PHAsset localidentifier…

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,28 @@ You can get a LocalIdentifier by using Photos Framework [Fetching Assets](https:
 
 A very basic application that uses the plugin can be found [here](https://github.com/vstirbu/instagramplugin-example).
 
+Additionally for IOS only, you can utilize a fourth parameter on the base64/canvas method `share`, to correspond with a mode:
+```
+console.log(Instagram.SHARE_MODES);
+> {
+    DEFAULT: 0, // original plugin logistics, where it checks for IOS Version 13+ to switch from IG to IGO mode. 
+    IGO: 1, // legacy UTI for instagram DI  (.exclusivegram)
+    IG: 2,  // new UTI for instagram DI  (.photo)
+    LIBRARY: 3 // save base64 or canvas to disk jpg, copy it to the Library, so that it can then be shared via App Intent
+}
+```
+Using above as definition, you can change your code as such (note the usage of a blank caption, to specify 4 total arguments, not 3): 
+```
+var caption = ''; // copied to clipboard by Cordova js. Instagram doesn't support feeding it anymore. 
+Instagram.share(canvasIdOrDataUrl, caption, function (err) {
+    if (err) {
+        console.log("not shared");
+    } else {
+        console.log("shared");
+    }
+}, Instagram.SHARE_MODES.LIBRARY);
+```
+
 ### AngularJS/Ionic
 
 The plugin is included in [ngCordova](http://ngcordova.com/docs/plugins/instagram/) and [ionic-native](https://github.com/driftyco/ionic-native).

--- a/www/CDVInstagramPlugin.js
+++ b/www/CDVInstagramPlugin.js
@@ -27,7 +27,7 @@ var exec = require('cordova/exec');
 var hasCheckedInstall,
     isAppInstalled;
 
-function shareDataUrl(dataUrl, caption, callback) {
+function shareDataUrl(dataUrl, caption, callback, mode) {
   var imageData = dataUrl.replace(/data:image\/(png|jpeg);base64,/, "");
 
     if (cordova && cordova.plugins && cordova.plugins.clipboard && caption !== '') {
@@ -41,11 +41,17 @@ function shareDataUrl(dataUrl, caption, callback) {
         },
         function (err) {
             callback && callback(err);
-        }, "Instagram", "share", [imageData, caption]
+        }, "Instagram", "share", [imageData, caption, mode]
     );
 }
 
 var Plugin = {
+  SHARE_MODES: {
+    DEFAULT: 0,
+    IGO: 1,
+    IG: 2,
+    LIBRARY: 3
+  },
   // calls to see if the device has the Instagram app
   isInstalled: function (callback) {
     exec(function (version) {
@@ -63,7 +69,8 @@ var Plugin = {
   share: function () {
     var data,
         caption,
-        callback;
+        callback,
+        mode = this.SHARE_MODES.DEFAULT; // existing code will continue to function as normal. But users can "opt in" to use mode 1,2 or 3.
 
     switch(arguments.length) {
     case 2:
@@ -76,6 +83,12 @@ var Plugin = {
       caption = arguments[1];
       callback = arguments[2];
       break;
+    case 4:
+        data = arguments[0];
+        caption = arguments[1];
+        callback = arguments[2];
+        mode = arguments[3];
+        break;
     default:
     }
 
@@ -89,10 +102,10 @@ var Plugin = {
         magic = "data:image";
 
     if (canvas) {
-      shareDataUrl(canvas.toDataURL(), caption, callback);
+      shareDataUrl(canvas.toDataURL(), caption, callback, mode);
     }
     else if (data.slice(0, magic.length) == magic) {
-      shareDataUrl(data, caption, callback);
+      shareDataUrl(data, caption, callback, mode);
     }
     else
     {


### PR DESCRIPTION
Which can then be opened by IG app intents  (instagram://library).

This was to bypass Document Interaction API approach, which is clearly not working on some IOS 14+ devices for specific Instagram versions.

Further notes:
The error messages in terminal from xcode do not indicate any reason why DI would fail. And on latest 14.4.1 of IOS with latest instagram, the code which is broken works fine.
I believe it's caused by instagram itself failing to process the "Copy to" DI event, since the error is resolved on latest.

Therefore this commit simply introduces developer control to specific precisely which "logic mode" (approach) to use.
You can use legacy... IGO (exclusivegram), or 13+  IG (photo), and now --- LIBRARY mode which works as described above.
DEFAULT Mode is ... the default. And so existing user code will be left unaffected by this change. It will continue as if no change was made.
User can opt-in to use the new logistics, if they so choose.

USE AT YOUR OWN RISK. Tested good for me though.

REF: https://github.com/vstirbu/InstagramPlugin/issues/117